### PR TITLE
Fish shell and Starship prompt

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -3,6 +3,7 @@ Makefile
 *.deb
 *.tar.gz
 .vscode
+LICENSE
 {{- if ne .chezmoi.os "linux" }}
 .hushlogin
 {{- end }}

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -10,13 +10,6 @@ HISTSIZE= HISTFILESIZE=
 # Enable completion
 [ -e /etc/bash_completion ] && source /etc/bash_completion
 
-# Prompt
-GIT_PROMPT="${HOME}/.git-prompt.sh"
-if [ -e "${GIT_PROMPT}" ] ; then
-    source "${GIT_PROMPT}"
-    export PS1='\[$(tput bold)\]\[$(tput setaf 3)\]\u\[$(tput setaf 2)\]@\[$(tput setaf 4)\]\h \[$(tput setaf 1)\]\W\[$(tput setaf 4)\]$(__git_ps1 " (%s)") \[$(tput setaf 7)\]\\$ \[$(tput sgr0)\]'
-fi
-
 # Source navi widget
 if command -v navi >/dev/null 2>&1 ; then
     source <(navi widget bash)
@@ -25,6 +18,11 @@ fi
 # Source chezmoi completion
 if command -v chezmoi >/dev/null 2>&1 ; then
     source <(chezmoi completion bash)
+fi
+
+# Starship prompt
+if command -v starship >/dev/null 2>&1 ; then
+    eval "$(starship init bash)"
 fi
 
 # Source Terraform completion

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -21,11 +21,6 @@ source $ZSH/oh-my-zsh.sh
 
 # User configuration
 
-# Shorten the displayed directory path to 3 elements
-prompt_dir() {
-    prompt_segment blue black '%(4~|.../%3~|%~)'
-}
-
 # Source navi widget
 if command -v navi >/dev/null 2>&1 ; then
     source <(navi widget zsh)
@@ -34,6 +29,11 @@ fi
 # Source chezmoi completion
 if command -v chezmoi >/dev/null 2>&1 ; then
     chezmoi completion zsh > $HOME/.zsh_completions/_chezmoi
+fi
+
+# Starship prompt
+if command -v starship >/dev/null 2>&1 ; then
+    eval "$(starship init zsh)"
 fi
 
 # Source github-cli completion

--- a/private_dot_config/fish/conf.d/abbr.fish
+++ b/private_dot_config/fish/conf.d/abbr.fish
@@ -1,0 +1,49 @@
+# Verbose for safety
+abbr -ga rm 'rm -i'
+abbr -ga cp 'cp -i'
+abbr -ga mv 'mv -i'
+
+# lsblk
+abbr -ga lk 'lsblk'
+
+# grep
+abbr -ga grep 'grep --color auto'
+
+# diff
+abbr -ga diff 'diff --unified --color auto'
+
+# git
+abbr -ga gs 'git status'
+abbr -ga gl 'git log --all --decorate --oneline --graph'
+abbr -ga gd 'git diff'
+abbr -ga ga 'git add'
+abbr -ga gaa 'git add .'
+abbr -ga gap 'git add --patch'
+abbr -ga gb 'git branch'
+abbr -ga gc 'git commit'
+abbr -ga gco 'git checkout'
+abbr -ga gco 'git clean'
+abbr -ga gcm 'git commit --message'
+abbr -ga gca 'git commit --amend'
+abbr -ga gri 'git rebase --interactive'
+
+# tmux
+abbr -ga tml 'tmux list-sessions'
+abbr -ga tma 'tmux attach-session -t'
+abbr -ga tmk 'tmux kill-session -t'
+abbr -ga tmn 'tmux new-session -A -s'
+
+# udiskie
+abbr -ga udm 'udiskie-mount --recursive'
+abbr -ga udu 'udiskie-umount --force'
+abbr -ga udua 'udiskie-umount --all'
+abbr -ga udd 'udiskie-umount --force --detach'
+abbr -ga udda 'udiskie-umount --all --detach'
+
+# Docker
+abbr -ga dkps 'docker ps --format "table {{.Names}}\\t{{.Image}}\\t{{.Status}}\\t{{.RunningFor}}"'
+abbr -ga dkrm 'docker rm --force'
+abbr -ga dkrmi 'docker rmi'
+abbr -ga dkls 'docker container ls'
+abbr -ga dklsi 'docker image ls'
+abbr -ga dkterm 'docker exec --tty --interactive'

--- a/private_dot_config/fish/conf.d/abbr.fish
+++ b/private_dot_config/fish/conf.d/abbr.fish
@@ -3,6 +3,17 @@ abbr -ga rm 'rm -i'
 abbr -ga cp 'cp -i'
 abbr -ga mv 'mv -i'
 
+# ls and exa
+if command -v exa >/dev/null 2>&1
+    abbr -ga ls 'exa --group-directories-first'
+    abbr -ga ll 'exa --group-directories-first --long'
+    abbr -ga la 'exa --group-directories-first --long --all'
+else
+    abbr -ga ls 'ls --color auto --group-directories-first'
+    abbr -ga ll 'ls --color auto --group-directories-first -l --human-readable'
+    abbr -ga la 'ls --color auto --group-directories-first -l --all --human-readable'
+end
+
 # lsblk
 abbr -ga lk 'lsblk'
 

--- a/private_dot_config/fish/config.fish
+++ b/private_dot_config/fish/config.fish
@@ -2,7 +2,7 @@
 fish_add_path $HOME/.fzf/bin
 
 if status is-interactive
-    set -U fish_greeting
+    set -g fish_greeting
     [ -f ~/.fzf/shell/key-bindings.fish ] && source ~/.fzf/shell/key-bindings.fish
     starship init fish | source
 end

--- a/private_dot_config/fish/config.fish
+++ b/private_dot_config/fish/config.fish
@@ -1,8 +1,15 @@
-# Path
+# Add FZF to path
 fish_add_path $HOME/.fzf/bin
 
 if status is-interactive
+
+    # Disable fish greeting
     set -g fish_greeting
+
+    # Load FZF keybindings function
     [ -f ~/.fzf/shell/key-bindings.fish ] && source ~/.fzf/shell/key-bindings.fish
+
+    # Use starship for the prompt
     starship init fish | source
+
 end

--- a/private_dot_config/fish/config.fish
+++ b/private_dot_config/fish/config.fish
@@ -1,3 +1,6 @@
+# Path
+fish_add_path $HOME/.fzf/bin
+
 if status is-interactive
     set -U fish_greeting
     [ -f ~/.fzf/shell/key-bindings.fish ] && source ~/.fzf/shell/key-bindings.fish

--- a/private_dot_config/fish/config.fish
+++ b/private_dot_config/fish/config.fish
@@ -1,0 +1,5 @@
+if status is-interactive
+    set -U fish_greeting
+    [ -f ~/.fzf/shell/key-bindings.fish ] && source ~/.fzf/shell/key-bindings.fish
+    starship init fish | source
+end

--- a/private_dot_config/fish/functions/fasd_cd.fish
+++ b/private_dot_config/fish/functions/fasd_cd.fish
@@ -1,0 +1,9 @@
+function fasd_cd -d "fasd builtin cd"
+    if test (count $argv) -le 1
+        command fasd "$argv"
+    else
+        fasd -e 'printf %s' $argv | read -l ret
+        test -z "$ret"; and return
+        test -d "$ret"; and cd "$ret"; or printf "%s\n" $ret
+    end
+end

--- a/private_dot_config/fish/functions/fish_user_key_bindings.fish
+++ b/private_dot_config/fish/functions/fish_user_key_bindings.fish
@@ -1,0 +1,3 @@
+function fish_user_key_bindings
+    fzf_key_bindings
+end

--- a/private_dot_config/fish/functions/fish_user_key_bindings.fish
+++ b/private_dot_config/fish/functions/fish_user_key_bindings.fish
@@ -1,3 +1,12 @@
 function fish_user_key_bindings
+
+    # FZF
     fzf_key_bindings
+
+    # Execute this once per mode that emacs bindings should be used in
+    fish_default_key_bindings -M insert
+
+    # Then execute the vi-bindings so they take precedence when there's a conflict
+    fish_vi_key_bindings --no-erase insert
+
 end

--- a/private_dot_config/fish/functions/z.fish
+++ b/private_dot_config/fish/functions/z.fish
@@ -1,0 +1,8 @@
+function z -d 'Jump to directory using fasd and fzf'
+    if count $argv > 0
+        fasd_cd -d "$argv"
+    else
+        cd (command fasd -Rdl $argv[1] | fzf -1 -0 --no-sort +m)
+    end
+end
+

--- a/private_dot_config/foot/foot.ini
+++ b/private_dot_config/foot/foot.ini
@@ -1,6 +1,6 @@
 # -*- conf -*-
 
-# shell=$SHELL (if set, otherwise user's default shell from /etc/passwd)
+shell=/usr/bin/fish
 # term=foot (or xterm-256color if built with -Dterminfo=disabled)
 # login-shell=no
 


### PR DESCRIPTION
This PR adds configurations for the Fish shell which is set to be used as the shell for `foot` at the moment but has not yet been set as the default shell for the user. This allows for the `~/.profile` to be loaded as it used to be without having to rewrite it for Fish, while still using FIsh shell in the terminal, since Fish does not load `~/.profile`.

Additionally, the Starship prompt is configured for all shells (bash, zsh, fish).