### PR TITLE
Add asdf support

### DIFF
--- a/dot_bashrc
+++ b/dot_bashrc
@@ -40,6 +40,7 @@ unset fasd_cache
 if [ -d "${HOME}/.asdf" ] ; then
     source "${HOME}/.asdf/asdf.sh"
     source "${HOME}/.asdf/completions/asdf.bash"
+    eval "$(asdf exec direnv hook bash)"
 fi
 
 # Enable fzf

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -36,6 +36,12 @@ fi
 source "${fasd_cache}"
 unset fasd_cache
 
+# Enable asdf
+if [ -d "${HOME}/.asdf" ] ; then
+    source "${HOME}/.asdf/asdf.sh"
+    source "${HOME}/.asdf/completions/asdf.bash"
+fi
+
 # Enable fzf
 [ -f ~/.fzf.bash ] && source ~/.fzf.bash
 

--- a/dot_gitignore_global
+++ b/dot_gitignore_global
@@ -1,3 +1,7 @@
+# asdf
+.tool-versions
+.envrc
+
 # Quilt patches
 .pc/
 patches/

--- a/private_dot_config/fish/completions/symlink_asdf.fish
+++ b/private_dot_config/fish/completions/symlink_asdf.fish
@@ -1,0 +1,1 @@
+/home/remi/.asdf/completions/asdf.fish

--- a/private_dot_config/fish/config.fish
+++ b/private_dot_config/fish/config.fish
@@ -10,8 +10,8 @@ if status is-interactive
     [ -f ~/.fzf/shell/key-bindings.fish ] && source ~/.fzf/shell/key-bindings.fish
 
     # Enable asdf
-    if [ -d "${HOME}/.asdf" ]
-        source ~/.asdf/asdf.fish
+    if [ -d "$HOME/.asdf" ]
+        source "$HOME/.asdf/asdf.fish"
         asdf exec direnv hook fish | source
     end
 

--- a/private_dot_config/fish/config.fish
+++ b/private_dot_config/fish/config.fish
@@ -10,7 +10,10 @@ if status is-interactive
     [ -f ~/.fzf/shell/key-bindings.fish ] && source ~/.fzf/shell/key-bindings.fish
 
     # Enable asdf
-    [ -f ~/.asdf/asdf.fish ] && source ~/.asdf/asdf.fish
+    if [ -d "${HOME}/.asdf" ]
+        source ~/.asdf/asdf.fish
+        asdf exec direnv hook fish | source
+    end
 
     # Use starship for the prompt
     starship init fish | source

--- a/private_dot_config/fish/config.fish
+++ b/private_dot_config/fish/config.fish
@@ -9,6 +9,9 @@ if status is-interactive
     # Load FZF keybindings function
     [ -f ~/.fzf/shell/key-bindings.fish ] && source ~/.fzf/shell/key-bindings.fish
 
+    # Enable asdf
+    [ -f ~/.asdf/asdf.fish ] && source ~/.asdf/asdf.fish
+
     # Use starship for the prompt
     starship init fish | source
 


### PR DESCRIPTION
This PR adds bash and fish support for the [asdf](https://asdf-vm.com/) runtime environment tool combined with [direnv](https://direnv.net/).